### PR TITLE
allow duplicate IP addresses from dns resolution

### DIFF
--- a/haproxy-native-integration/haproxy.cfg
+++ b/haproxy-native-integration/haproxy.cfg
@@ -47,7 +47,7 @@ frontend http_front
 
 backend http_back
    balance roundrobin
-    server-template mywebapp 10 _web._tcp.service.consul resolvers consul resolve-prefer ipv4 check
+    server-template mywebapp 10 _web._tcp.service.consul resolvers consul resolve-opts allow-dup-ip resolve-prefer ipv4 check
 
 resolvers consul
   nameserver consul 127.0.0.1:8600


### PR DESCRIPTION
This allows for multiple instances of a service running on the same server to be served by the backend (useful for rolling/canary deploys). Without `resolve-opts allow-dup-ip`, haproxy skips on any repeat service node (duplicate ip – even with a different port).

Detailed info in this issue: https://github.com/hashicorp/consul/issues/5968